### PR TITLE
Rento yabuki06/issue3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 .venv/
+__pycache__/
+*.pyc
+.DS_Store

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,7 +1,13 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, BackgroundTasks
 
 router = APIRouter(prefix="/admin", tags=["admin"]) 
 
 @router.get("/healthz")
 async def healthz():
     return {"status": "ok"}
+
+@router.post("/run-now")
+async def run_now(background_tasks: BackgroundTasks):
+    from app.services.pipeline import run_pipeline
+    background_tasks.add_task(run_pipeline)
+    return {"status": "queued"}

--- a/app/services/pipeline.py
+++ b/app/services/pipeline.py
@@ -1,0 +1,4 @@
+import asyncio
+
+async def run_pipeline():
+	await asyncio.sleep(0)


### PR DESCRIPTION
This pull request introduces a new admin endpoint to allow triggering the pipeline to run asynchronously via an HTTP request. The main changes are the addition of a new route in `admin.py` and the creation of an asynchronous pipeline runner function.

**New admin endpoint for pipeline execution:**

* Added a `POST /admin/run-now` route to `app/routers/admin.py` that queues the pipeline to run in the background using FastAPI's `BackgroundTasks`.

**Pipeline runner implementation:**

* Created an asynchronous `run_pipeline` function in `app/services/pipeline.py` to be executed by the new endpoint. Currently, this function is a stub using `asyncio.sleep(0)` as a placeholder for future pipeline logic.